### PR TITLE
Null check for invoking OnAnimationEnd. Related Issue #21

### DIFF
--- a/source/MonoGame.Aseprite/Graphics/AnimatedSprite.cs
+++ b/source/MonoGame.Aseprite/Graphics/AnimatedSprite.cs
@@ -547,7 +547,7 @@ namespace MonoGame.Aseprite.Graphics
             if (Animating)
             {
                 Animating = false;
-                OnAnimationEnd.Invoke();
+                OnAnimationEnd?.Invoke();
             }
         }
 


### PR DESCRIPTION
Null checking was correctly added before invoking `OnAnimationEnd` within the `AnimatedSprite.Stop()` method.